### PR TITLE
Fix unintentional string to int conversion - Fixes #13

### DIFF
--- a/src/ShopCertification.php
+++ b/src/ShopCertification.php
@@ -125,13 +125,13 @@ class ShopCertification
     {
         $productItemId = (string)$productItemId;
 
-        if (isset($this->productItemIds[$productItemId])) {
+        if (array_search($productItemId, $this->productItemIds) !== false) {
             throw new DuplicateProductItemIdException(
                 'The productItemId "%s" was already added. Please check the implementation.'
             );
         }
 
-        $this->productItemIds[$productItemId] = true;
+        $this->productItemIds[] = $productItemId;
 
         return $this;
     }
@@ -160,7 +160,7 @@ class ShopCertification
             $data['orderId'] = $this->orderId;
         }
 
-        $data['productItemIds'] = array_keys($this->productItemIds);
+        $data['productItemIds'] = $this->productItemIds;
 
         $result = $this->requester->request(IRequester::ACTION_LOG_ORDER, $data);
         if ($result->code !== 200) {

--- a/tests/ShopCertificationTest.php
+++ b/tests/ShopCertificationTest.php
@@ -54,7 +54,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $requester->shouldReceive('request')
             ->once()
-            ->with(IRequester::ACTION_LOG_ORDER, $data)
+            ->with(IRequester::ACTION_LOG_ORDER, Mockery::mustBe($data))
             ->andReturn($response);
 
         $shopCertification = new ShopCertification($apiKey, [], $requester);
@@ -87,7 +87,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $requester->shouldReceive('request')
             ->once()
-            ->with(IRequester::ACTION_LOG_ORDER, $data)
+            ->with(IRequester::ACTION_LOG_ORDER, Mockery::mustBe($data))
             ->andReturn($response);
 
         $shopCertification = new ShopCertification($apiKey, [], $requester);
@@ -133,7 +133,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $requester->shouldReceive('request')
             ->once()
-            ->with(IRequester::ACTION_LOG_ORDER, $data)
+            ->with(IRequester::ACTION_LOG_ORDER, Mockery::mustBe($data))
             ->andReturn($response);
 
         $shopCertification = new ShopCertification($apiKey, [], $requester);
@@ -168,7 +168,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $requester->shouldReceive('request')
             ->once()
-            ->with(IRequester::ACTION_LOG_ORDER, $data)
+            ->with(IRequester::ACTION_LOG_ORDER, Mockery::mustBe($data))
             ->andReturn($response);
 
         $shopCertification = new ShopCertification($apiKey, [], $requester);


### PR DESCRIPTION
PHP automatically converts all string which appears as integers to integers if they are put into an array key. And we failed to notice that because our tests were not strict enough, unfortunately.

Both problems are fixed now.

