### PR TITLE
Add more stable PHP versions to the Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,10 @@ php:
   - 7.2
   - 7.3
   - hhvm
+  - nightly
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: nightly
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 script:
   - make test


### PR DESCRIPTION
I've added more stable PHP versions and check it on my Travis CI:

https://travis-ci.org/vojtasvoboda/overeno-zakazniky/builds/555836185