### PR TITLE
Add missing sprintf function

### DIFF
--- a/src/ShopCertification.php
+++ b/src/ShopCertification.php
@@ -127,7 +127,7 @@ class ShopCertification
 
         if (array_search($productItemId, $this->productItemIds) !== false) {
             throw new DuplicateProductItemIdException(
-                'The productItemId "%s" was already added. Please check the implementation.'
+                sprintf('The productItemId "%s" was already added. Please check the implementation.', $productItemId)
             );
         }
 


### PR DESCRIPTION
Add missing `sprintf` function. Without `sprintf` it prints just:

```
The productItemId "%s" was already added. Please check the implementation.
```