### PR TITLE
Add support for PHP 7.4/8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,7 @@
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
   - 7.3
-  - hhvm
-  - nightly
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: nightly
+  - 7.4
+  - 8.0
 script:
   - make test

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "ext-curl": "Simplifies the library usage (you don't have to provide your own requester)"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.0",
-        "mockery/mockery": "~0.9.4"
+        "phpunit/phpunit": "~9.5.0",
+        "mockery/mockery": "~1.4.3"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ShopCertification/ApiEndpointTest.php
+++ b/tests/ShopCertification/ApiEndpointTest.php
@@ -7,7 +7,7 @@ use Heureka\ShopCertification;
 /**
  * @author Jakub Chábek <jakub.chabek@heureka.cz>
  */
-class ApiEndpointTest extends \PHPUnit_Framework_TestCase
+class ApiEndpointTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testGetEndpoint()
@@ -18,7 +18,7 @@ class ApiEndpointTest extends \PHPUnit_Framework_TestCase
         $apiEndpoint = new ApiEndpoint(ShopCertification::HEUREKA_SK);
         $this->assertSame(ApiEndpoint::API_ENDPOINT_SK, $apiEndpoint->getUrl());
 
-        $this->setExpectedException('Heureka\ShopCertification\UnknownServiceException');
+        $this->expectException('Heureka\ShopCertification\UnknownServiceException');
         new ApiEndpoint(15);
     }
 

--- a/tests/ShopCertification/ResponseTest.php
+++ b/tests/ShopCertification/ResponseTest.php
@@ -5,7 +5,7 @@ namespace Heureka\ShopCertification;
 /**
  * @author Jakub Chábek <jakub.chabek@heureka.cz>
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
@@ -43,7 +43,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructWithMissingFields()
     {
-        $this->setExpectedException('Heureka\ShopCertification\InvalidResponseException');
+        $this->expectException('Heureka\ShopCertification\InvalidResponseException');
         new Response('{"message":"There was an error"}');
     }
 
@@ -54,7 +54,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructWithInvalidJsonResponse($json)
     {
-        $this->setExpectedException('Heureka\ShopCertification\JsonException');
+        $this->expectException('Heureka\ShopCertification\JsonException');
         new Response($json);
     }
 

--- a/tests/ShopCertificationTest.php
+++ b/tests/ShopCertificationTest.php
@@ -10,10 +10,10 @@ require_once __DIR__ . '/../vendor/autoload.php';
 /**
  * @author Jakub Chábek <jakub.chabek@heureka.cz>
  */
-class ShopCertificationTest extends \PHPUnit_Framework_TestCase
+class ShopCertificationTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
@@ -27,7 +27,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $shopCertification = new ShopCertification('xxxxxxxx', [], $requester);
 
-        $this->setExpectedException('\Heureka\ShopCertification\InvalidArgumentException');
+        $this->expectException('\Heureka\ShopCertification\InvalidArgumentException');
         $shopCertification->setOrderId('abcd');
     }
 
@@ -104,7 +104,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
 
         $shopCertification = new ShopCertification('xxxxxxxxxx', [], $requester);
 
-        $this->setExpectedException('\Heureka\ShopCertification\MissingInformationException');
+        $this->expectException('\Heureka\ShopCertification\MissingInformationException');
         $shopCertification->logOrder();
     }
 
@@ -139,7 +139,7 @@ class ShopCertificationTest extends \PHPUnit_Framework_TestCase
         $shopCertification->addProductItemId($product2);
         $shopCertification->logOrder();
 
-        $this->setExpectedException('\Heureka\ShopCertification\Exception');
+        $this->expectException('\Heureka\ShopCertification\Exception');
         $shopCertification->logOrder();
     }
 


### PR DESCRIPTION
Keep only [supported PHP versions](https://www.php.net/supported-versions.php), add 7.4 and 8.0.

Upgrade mockery/mockery from 0.9.4 to 1.4.3 because an old version was not compatible with PHP 7.4/8.0, throws `Cannot use "parent" when current class scope has no parent` error.

Upgrade phpunit/phpunit (required by mockery) and migrate tests to the new version.

All tests are green: https://travis-ci.org/github/vojtasvoboda/overeno-zakazniky/builds/770689734