### PR TITLE
Add some timeout to requests

### DIFF
--- a/src/ShopCertification/CurlRequester.php
+++ b/src/ShopCertification/CurlRequester.php
@@ -30,6 +30,7 @@ class CurlRequester implements IRequester
         try {
             $curlOptions = [
                 CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_TIMEOUT => 5,
             ];
 
             if ($postData) {


### PR DESCRIPTION
When requests to Heureka timeout it takes too long if timeout is set to default (infinite). Some reasonable timeout limit makes RequesterException get thrown earlier and only then it can get caught in application before it timeouts too. 5 seconds is just an example and can be replaced by whatever value but I think it should be shorter than 30 seconds. 